### PR TITLE
Allow to ignore a dperecation on the next triggering.

### DIFF
--- a/lib/Doctrine/Deprecations/Deprecation.php
+++ b/lib/Doctrine/Deprecations/Deprecation.php
@@ -57,6 +57,9 @@ class Deprecation
     /** @var array<string,int> */
     private static $ignoredLinks = [];
 
+    /** @var array<string,bool> */
+    private static $ignoreLinkOnce = [];
+
     /**
      * Trigger a deprecation for the given package, starting with given version.
      *
@@ -74,6 +77,12 @@ class Deprecation
 
         if (array_key_exists($link, self::$ignoredLinks)) {
             self::$ignoredLinks[$link]++;
+
+            return;
+        }
+
+        if (array_key_exists($link, self::$ignoreLinkOnce)) {
+            unset(self::$ignoreLinkOnce[$link]);
 
             return;
         }
@@ -165,6 +174,15 @@ class Deprecation
         foreach ($links as $link) {
             self::$ignoredLinks[$link] = 0;
         }
+    }
+
+    public static function ignoreDeprecationOnce(string $link, ?string $package = null)
+    {
+        if (is_numeric($link)) {
+            $link = 'https://github.com/' . $package . '/issue/' . $link;
+        }
+
+        self::$ignoreLinkOnce[$link] = true;
     }
 
     public static function getUniqueTriggeredDeprecationsCount(): int

--- a/tests/Doctrine/Deprecations/DeprecationTest.php
+++ b/tests/Doctrine/Deprecations/DeprecationTest.php
@@ -152,4 +152,37 @@ class DeprecationTest extends TestCase
         $this->assertEquals(1, Deprecation::getUniqueTriggeredDeprecationsCount());
         $this->assertEquals(['https://github.com/doctrine/orm/issue/1234' => 1], Deprecation::getTriggeredDeprecations());
     }
+
+    public function testDeprecationIgnoredOnce(): void
+    {
+        Deprecation::enableWithTriggerError();
+
+        Deprecation::ignoreDeprecationOnce('1234', 'doctrine/orm');
+
+        $this->triggerDeprecation();
+
+        $this->expectDeprecation();
+        $this->expectDeprecationMessage('this is deprecated foo 1234 (DeprecationTest.php');
+
+        try {
+            $this->triggerDeprecation();
+        } catch (Throwable $e) {
+            $this->assertEquals(1, Deprecation::getUniqueTriggeredDeprecationsCount());
+            $this->assertEquals(['https://github.com/doctrine/orm/issue/1234' => 1], Deprecation::getTriggeredDeprecations());
+
+            throw $e;
+        }
+    }
+
+    private function triggerDeprecation()
+    {
+        Deprecation::trigger(
+            'doctrine/orm',
+            '2.7',
+            '1234',
+            'this is deprecated %s %d',
+            'foo',
+            1234
+        );
+    }
 }


### PR DESCRIPTION
This is useful if you know you call a deprecated API next, but
its necessary for the transition towards the new API to do this.