### PR TITLE
Remove $version identifier for first deprecation occurrence.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Enable Doctrine deprecations to be sent to a PSR3 logger:
 \Doctrine\Deprecations\Deprecation::enableWithPsrLogger($logger);
 ```
 
-Disable deprecations from a package, starting at given version and above
+Disable deprecations from a package
 
 ```php
-\Doctrine\Deprecations\Deprecation::ignorePackage("doctrine/orm", "2.8");
+\Doctrine\Deprecations\Deprecation::ignorePackage("doctrine/orm");
 ```
 
 Disable triggering about specific deprecations:
@@ -52,7 +52,6 @@ foreach ($deprecations as $identifier => $count) {
 ```php
 \Doctrine\Deprecations\Deprecation::trigger(
     "doctrine/orm",
-    "2.7",
     "https://link/to/deprecations-description",
     "message"
 );
@@ -64,7 +63,6 @@ the message.
 ```php
 \Doctrine\Deprecations\Deprecation::trigger(
     "doctrine/orm",
-    "2.7",
     "https://github.com/doctrine/orm/issue/1234",
     "message %s %d",
     "foo",

--- a/lib/Doctrine/Deprecations/Deprecation.php
+++ b/lib/Doctrine/Deprecations/Deprecation.php
@@ -10,10 +10,8 @@ use function array_key_exists;
 use function array_reduce;
 use function basename;
 use function debug_backtrace;
-use function is_numeric;
 use function sprintf;
 use function trigger_error;
-use function version_compare;
 
 use const DEBUG_BACKTRACE_IGNORE_ARGS;
 use const E_USER_DEPRECATED;
@@ -66,7 +64,7 @@ class Deprecation
      *
      * @param mixed $args
      */
-    public static function trigger(string $package, string $version, string $link, string $message, ...$args): void
+    public static function trigger(string $package, string $link, string $message, ...$args): void
     {
         if (array_key_exists($link, self::$ignoredLinks)) {
             self::$ignoredLinks[$link]++;
@@ -83,7 +81,7 @@ class Deprecation
             return;
         }
 
-        if (isset(self::$ignoredPackages[$package]) && version_compare($version, self::$ignoredPackages[$package]) >= 0) {
+        if (isset(self::$ignoredPackages[$package])) {
             return;
         }
 
@@ -93,23 +91,21 @@ class Deprecation
 
         if (self::$type === self::TYPE_TRIGGER_ERROR) {
             $message .= sprintf(
-                ' (%s:%s, %s, since %s %s)',
+                ' (%s:%s, %s, package %s)',
                 basename($backtrace[0]['file']),
                 $backtrace[0]['line'],
                 $link,
-                $package,
-                $version
+                $package
             );
 
             trigger_error($message, E_USER_DEPRECATED);
         } elseif (self::$type === self::TYPE_TRIGGER_SUPPRESSED_ERROR) {
             $message .= sprintf(
-                ' (%s:%s, %s, since %s %s)',
+                ' (%s:%s, %s, package %s)',
                 basename($backtrace[0]['file']),
                 $backtrace[0]['line'],
                 $link,
-                $package,
-                $version
+                $package
             );
 
             @trigger_error($message, E_USER_DEPRECATED);
@@ -120,7 +116,6 @@ class Deprecation
             ];
 
             $context['package'] = $package;
-            $context['since']   = $version;
             $context['link']    = $link;
 
             self::$logger->notice($message, $context);
@@ -153,9 +148,9 @@ class Deprecation
         }
     }
 
-    public static function ignorePackage(string $packageName, string $version = '0.0.1'): void
+    public static function ignorePackage(string $packageName): void
     {
-        self::$ignoredPackages[$packageName] = $version;
+        self::$ignoredPackages[$packageName] = true;
     }
 
     public static function ignoreDeprecations(string ...$links): void

--- a/tests/Doctrine/Deprecations/DeprecationTest.php
+++ b/tests/Doctrine/Deprecations/DeprecationTest.php
@@ -54,7 +54,6 @@ class DeprecationTest extends TestCase
         try {
             Deprecation::trigger(
                 'doctrine/orm',
-                '2.7',
                 'https://github.com/doctrine/deprecations/1234',
                 'this is deprecated %s %d',
                 'foo',
@@ -73,7 +72,6 @@ class DeprecationTest extends TestCase
         try {
             Deprecation::trigger(
                 'doctrine/orm',
-                '2.7',
                 'https://github.com/doctrine/deprecations/1234',
                 'this is deprecated %s %d',
                 'foo',
@@ -93,7 +91,6 @@ class DeprecationTest extends TestCase
         $mock->method('notice')->with('this is deprecated foo 1234', $this->callback(function ($context) {
             $this->assertEquals(__FILE__, $context['file']);
             $this->assertEquals('doctrine/orm', $context['package']);
-            $this->assertEquals('2.7', $context['since']);
             $this->assertEquals('https://github.com/doctrine/deprecations/2222', $context['link']);
 
             return true;
@@ -103,7 +100,6 @@ class DeprecationTest extends TestCase
 
         Deprecation::trigger(
             'doctrine/orm',
-            '2.7',
             'https://github.com/doctrine/deprecations/2222',
             'this is deprecated %s %d',
             'foo',
@@ -114,11 +110,10 @@ class DeprecationTest extends TestCase
     public function testDeprecationWithIgnoredPackage(): void
     {
         Deprecation::enableWithTriggerError();
-        Deprecation::ignorePackage('doctrine/orm', '2.8');
+        Deprecation::ignorePackage('doctrine/orm');
 
         Deprecation::trigger(
             'doctrine/orm',
-            '2.8',
             'https://github.com/doctrine/orm/issue/1234',
             'this is deprecated %s %d',
             'foo',


### PR DESCRIPTION
There isn't much value in adding the first version that a deprecation started appearing in, because it does not mean that an alternative API is already available. Each deprecation is different and we acknowledge this by linking to an issue or PR directly in the deprecation. It can contain all the information:

- When was the deprecation introduced?
- Is there a replacement API?
- When will the deprecated behavior be removed?