### PR TITLE
Add VerifyDeprecations trait for assertions on deprecations in PHPUnit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,27 @@ request, so it must be unique for each deprecation.
 A limited stacktrace is included in the deprecation message to find the
 offending location.
 
+## Usage in PHPUnit tests
+
+There is a `VerifyDeprecations` trait that you can use to make assertions on
+the occurrence of deprecations within a test.
+
+```php
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+
+class MyTest extends TestCase
+{
+    use VerifyDeprecations;
+
+    public function testSomethingDeprecation()
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issue/1234');
+
+        triggerTheCodeWithDeprecation();
+    }
+}
+```
+
 ## What is a deprecation identifier?
 
 An identifier for deprecations is just a link to any resource, most often a

--- a/lib/Doctrine/Deprecations/Deprecation.php
+++ b/lib/Doctrine/Deprecations/Deprecation.php
@@ -10,7 +10,6 @@ use function array_key_exists;
 use function array_reduce;
 use function basename;
 use function debug_backtrace;
-use function is_numeric;
 use function sprintf;
 use function trigger_error;
 use function version_compare;

--- a/lib/Doctrine/Deprecations/PHPUnit/VerifyDeprecations.php
+++ b/lib/Doctrine/Deprecations/PHPUnit/VerifyDeprecations.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Deprecations\PHPUnit;
+
+use Doctrine\Deprecations\Deprecation;
+
+use function sprintf;
+
+trait VerifyDeprecations
+{
+    /** @var array<string,int> */
+    private $doctrineDeprecationsExpectations = [];
+
+    public function expectDeprecationWithIdentifier(string $identifier): void
+    {
+        $this->doctrineDeprecationsExpectations[$identifier] = Deprecation::getTriggeredDeprecations()[$identifier] ?? 0;
+    }
+
+    /**
+     * @after
+     */
+    public function verifyDeprecationsAreTriggered(): void
+    {
+        foreach ($this->doctrineDeprecationsExpectations as $identifier => $expectation) {
+            $actualCount = Deprecation::getTriggeredDeprecations()[$identifier] ?? 0;
+
+            $this->assertTrue(
+                $actualCount > $expectation,
+                sprintf(
+                    "Expected deprecation with identifier '%s' was not triggered by code executed in test.",
+                    $identifier
+                )
+            );
+        }
+    }
+}

--- a/tests/Doctrine/Deprecations/DeprecationTest.php
+++ b/tests/Doctrine/Deprecations/DeprecationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Deprecations;
 
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\Error\Deprecated;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -14,6 +15,8 @@ use function method_exists;
 
 class DeprecationTest extends TestCase
 {
+    use VerifyDeprecations;
+
     public function setUp(): void
     {
         // reset the global state of Deprecation class accross tests
@@ -50,6 +53,8 @@ class DeprecationTest extends TestCase
 
         $this->expectDeprecation();
         $this->expectDeprecationMessage('this is deprecated foo 1234 (DeprecationTest.php');
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/deprecations/1234');
 
         try {
             Deprecation::trigger(
@@ -89,6 +94,8 @@ class DeprecationTest extends TestCase
 
     public function testDeprecationWithPsrLogger(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/deprecations/2222');
+
         $mock = $this->createMock(LoggerInterface::class);
         $mock->method('notice')->with('this is deprecated foo 1234', $this->callback(function ($context) {
             $this->assertEquals(__FILE__, $context['file']);


### PR DESCRIPTION
While integrating doctrine/deprecations into ORM, the existence of `VerifyDeprecations` trait there showed that we need this directly in the library here.

There is a `VerifyDeprecations` trait that you can use to make assertions on
the occurrence of deprecations within a test.

```php
use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;

class MyTest extends TestCase
{
    use VerifyDeprecations;

    public function testSomethingDeprecation()
    {
        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issue/1234');

        triggerTheCodeWithDeprecation();
    }
}
```
