### PR TITLE
Simplify modes, allow stacking them, no tracking by default. Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ If you only want to enable deprecation tracking, without logging or calling `tri
 \Doctrine\Deprecations\Deprecation::enableTrackingDeprecations();
 ```
 
-Access is provided to all triggered deprecations and their individual count:
+Tracking is enabled with all three modes and provides access to all triggered
+deprecations and their individual count:
 
 ```php
 $deprecations = \Doctrine\Deprecations\Deprecation::getTriggeredDeprecations();

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A small (side-effect free by default) layer on top of
 `trigger_error(E_USER_DEPRECATED)` or PSR-3 logging.
 
 - no side-effects by default, making it a perfect fit for libraries that don't know how the error handler works they operate under
-- options to avoid having to rely on global state entirely with PSR-3 logging
+- options to avoid having to rely on error handlers global state by using PSR-3 logging
 - deduplicate deprecation messages to avoid excessive triggering and reduce overhead
 
 We recommend to collect Deprecations using a PSR logger instead of relying on
@@ -25,7 +25,7 @@ messages.
 \Doctrine\Deprecations\Deprecation::enableWithTriggerError();
 ```
 
-If you only want to enable depreaction tracking, without logging or calling `trigger_error` then call:
+If you only want to enable deprecation tracking, without logging or calling `trigger_error` then call:
 
 ```php
 \Doctrine\Deprecations\Deprecation::enableTrackingDeprecations();
@@ -41,7 +41,7 @@ foreach ($deprecations as $identifier => $count) {
 }
 ```
 
-### Supressing Specifc Deprecations
+### Suppressing Specific Deprecations
 
 Disable triggering about specific deprecations:
 

--- a/lib/Doctrine/Deprecations/Deprecation.php
+++ b/lib/Doctrine/Deprecations/Deprecation.php
@@ -8,34 +8,36 @@ use Psr\Log\LoggerInterface;
 
 use function array_key_exists;
 use function array_reduce;
-use function basename;
 use function debug_backtrace;
 use function sprintf;
 use function strpos;
+use function strrpos;
+use function substr;
 use function trigger_error;
 
 use const DEBUG_BACKTRACE_IGNORE_ARGS;
+use const DIRECTORY_SEPARATOR;
 use const E_USER_DEPRECATED;
 
 /**
  * Manages Deprecation logging in different ways.
  *
- * By default triggered exceptions are not logged, only the amount of
- * deprecations triggered can be queried with `Deprecation::getUniqueTriggeredDeprecationsCount()`.
+ * By default triggered exceptions are not logged.
  *
  * To enable different deprecation logging mechanisms you can call the
  * following methods:
  *
- *  - Uses trigger_error with E_USER_DEPRECATED
- *    \Doctrine\Deprecations\Deprecation::enableWithTriggerError();
+ *  - Minimal collection of deprecations via getTriggeredDeprecations()
+ *    \Doctrine\Deprecations\Deprecation::enableTrackingDeprecations();
  *
  *  - Uses @trigger_error with E_USER_DEPRECATED
- *    \Doctrine\Deprecations\Deprecation::enableWithSuppressedTriggerError();
+ *    \Doctrine\Deprecations\Deprecation::enableWithTriggerError();
  *
  *  - Sends deprecation messages via a PSR-3 logger
  *    \Doctrine\Deprecations\Deprecation::enableWithPsrLogger($logger);
  *
- * Packages that trigger deprecations should use the `trigger()` method.
+ * Packages that trigger deprecations should use the `trigger()` or
+ * `triggerIfCalledFromOutside()` methods.
  */
 class Deprecation
 {
@@ -60,7 +62,7 @@ class Deprecation
     private static $deduplication = true;
 
     /**
-     * Trigger a deprecation for the given package, starting with given version.
+     * Trigger a deprecation for the given package and identfier.
      *
      * The link should point to a Github issue or Wiki entry detailing the
      * deprecation. It is additionally used to de-duplicate the trigger of the
@@ -96,6 +98,22 @@ class Deprecation
     }
 
     /**
+     * Trigger a deprecation for the given package and identifier when called from outside.
+     *
+     * "Outside" means we assume that $package is currently installed as a
+     * dependency and the caller is not a file in that package. When $package
+     * is installed as a root package then deprecations triggered from the
+     * tests folder are also considered "outside".
+     *
+     * This deprecation method assumes that you are using Composer to install
+     * the dependency and are using the default /vendor/ folder and not a
+     * Composer plugin to change the install location. The assumption is also
+     * that $package is the exact composer packge name.
+     *
+     * Compared to {@link trigger()} this method causes some overhead when
+     * deprecation tracking is enabled even during deduplication, because it
+     * needs to call {@link debug_backtrace()}
+     *
      * @param mixed $args
      */
     public static function triggerIfCalledFromOutside(string $package, string $link, string $message, ...$args): void
@@ -106,10 +124,6 @@ class Deprecation
 
         $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
 
-        // "outside" means we assume that $package is currently installed as a
-        // dependency and the caller is not a file in that package.
-        // When $package is installed as a root package, then this deprecation
-        // is always ignored
         // first check that the caller is not from a tests folder, in which case we always let deprecations pass
         if (strpos($backtrace[1]['file'], '/tests/') === false) {
             if (strpos($backtrace[0]['file'], '/vendor/' . $package . '/') === false) {
@@ -149,10 +163,9 @@ class Deprecation
             $context = [
                 'file' => $backtrace[0]['file'],
                 'line' => $backtrace[0]['line'],
+                'package' => $package,
+                'link' => $link,
             ];
-
-            $context['package'] = $package;
-            $context['link']    = $link;
 
             self::$logger->notice($message, $context);
         }
@@ -163,15 +176,29 @@ class Deprecation
 
         $message .= sprintf(
             ' (%s:%d called by %s:%d, %s, package %s)',
-            basename($backtrace[0]['file']),
+            self::basename($backtrace[0]['file']),
             $backtrace[0]['line'],
-            basename($backtrace[1]['file']),
+            self::basename($backtrace[1]['file']),
             $backtrace[1]['line'],
             $link,
             $package
         );
 
         @trigger_error($message, E_USER_DEPRECATED);
+    }
+
+    /**
+     * A non-local-aware version of PHPs basename function.
+     */
+    private static function basename(string $filename): string
+    {
+        $pos = strrpos($filename, DIRECTORY_SEPARATOR);
+
+        if ($pos === false) {
+            return $filename;
+        }
+
+        return substr($filename, $pos + 1);
     }
 
     public static function enableTrackingDeprecations(): void

--- a/lib/Doctrine/Deprecations/PHPUnit/VerifyDeprecations.php
+++ b/lib/Doctrine/Deprecations/PHPUnit/VerifyDeprecations.php
@@ -27,6 +27,14 @@ trait VerifyDeprecations
     }
 
     /**
+     * @before
+     */
+    public function enableDeprecationTracking(): void
+    {
+        Deprecation::enableTrackingDeprecations();
+    }
+
+    /**
      * @after
      */
     public function verifyDeprecationsAreTriggered(): void

--- a/test_fixtures/src/Foo.php
+++ b/test_fixtures/src/Foo.php
@@ -8,13 +8,13 @@ use Doctrine\Foo\Bar;
 
 class Foo
 {
-    public function triggerDependencyWithDeprecation(): void
+    public static function triggerDependencyWithDeprecation(): void
     {
         $bar = new Bar();
         $bar->oldFunc();
     }
 
-    public function triggerDependencyWithDeprecationFromInside(): void
+    public static function triggerDependencyWithDeprecationFromInside(): void
     {
         $bar = new Bar();
         $bar->newFunc();

--- a/tests/Doctrine/Deprecations/VerifyDeprecationsTest.php
+++ b/tests/Doctrine/Deprecations/VerifyDeprecationsTest.php
@@ -7,17 +7,16 @@ namespace Doctrine\Deprecations;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\TestCase;
 
+use function set_error_handler;
+
 class VerifyDeprecationsTest extends TestCase
 {
     use VerifyDeprecations;
 
-    /**
-     * @before
-     */
-    public function setUpDisableDeprecations(): void
+    public function setUp(): void
     {
-        // prevent PHPUnit from throwing Deprecation exception in case trigger_error was enabled before
-        Deprecation::disable();
+        set_error_handler(static function (): void {
+        });
     }
 
     public function testExpectDeprecationWithIdentifier(): void


### PR DESCRIPTION
- By default do not even count the occurrences of deprecations anymore to avoid overhead with `triggerIfCalledFromOutside`.
- Remove `trigger_error` based mode and only use `@trigger_error`, refactor tests to use a custom error handler for assertions.
- Allow to combine PSR-3 logger and `@trigger_error`
- Improve README and docblocks.
- Use a userland basename implementation to avoid locale-sensitiviy.