### PR TITLE
Fix deprecation ignore by link

### DIFF
--- a/lib/Doctrine/Deprecations/Deprecation.php
+++ b/lib/Doctrine/Deprecations/Deprecation.php
@@ -243,7 +243,7 @@ class Deprecation
     public static function ignoreDeprecations(string ...$links): void
     {
         foreach ($links as $link) {
-            self::$ignoredLinks[$link] = 0;
+            self::$ignoredLinks[$link] = 1;
         }
     }
 

--- a/tests/Doctrine/Deprecations/DeprecationTest.php
+++ b/tests/Doctrine/Deprecations/DeprecationTest.php
@@ -202,6 +202,23 @@ class DeprecationTest extends TestCase
         $this->assertEquals(['https://github.com/doctrine/orm/issue/1234' => 1], Deprecation::getTriggeredDeprecations());
     }
 
+    public function testDeprecationWithIgnoredLink(): void
+    {
+        Deprecation::enableWithTriggerError();
+        Deprecation::ignoreDeprecations('https://github.com/doctrine/orm/issue/1234');
+
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/issue/1234',
+            'this is deprecated %s %d',
+            'foo',
+            1234
+        );
+
+        $this->assertEquals(1, Deprecation::getUniqueTriggeredDeprecationsCount());
+        $this->assertEquals(['https://github.com/doctrine/orm/issue/1234' => 1], Deprecation::getTriggeredDeprecations());
+    }
+
     public function testDeprecationIfCalledFromOutside(): void
     {
         Deprecation::enableWithTriggerError();


### PR DESCRIPTION
Initial value in `ignoredLinks` must be set to 1, same as https://github.com/doctrine/deprecations/blob/master/lib/Doctrine/Deprecations/Deprecation.php#L143 Otherwise the error is not ignored.