### PR TITLE
Allow psr/log 2 and 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5|^8.5|^9.5",
-        "psr/log": "^1.0",
+        "psr/log": "^1|^2|^3",
         "doctrine/coding-standard": "^9"
     },
     "suggest": {


### PR DESCRIPTION
We should run our tests with higher versions of psr/log as well. This PR enables testing against psr/log 3 on PHP 8.0 and above.