### PR TITLE
Allow configuring behavior via the DOCTRINE_DEPRECATIONS env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,16 @@ Enable Doctrine deprecations to be sent to a PSR3 logger:
 ```
 
 Enable Doctrine deprecations to be sent as `@trigger_error($message, E_USER_DEPRECATED)`
-messages.
+messages by setting the `DOCTRINE_DEPRECATIONS` environment variable to `trigger`.
+Alternatively, call:
 
 ```php
 \Doctrine\Deprecations\Deprecation::enableWithTriggerError();
 ```
 
-If you only want to enable deprecation tracking, without logging or calling `trigger_error` then call:
+If you only want to enable deprecation tracking, without logging or calling `trigger_error`
+then set the `DOCTRINE_DEPRECATIONS` environment variable to `track`.
+Alternatively, call:
 
 ```php
 \Doctrine\Deprecations\Deprecation::enableTrackingDeprecations();


### PR DESCRIPTION
In https://github.com/doctrine/DoctrineBundle/issues/1662, we're discussing about how we should best integrate this lib in Symfony, where we'd like the default to be to call trigger_error.

In order to not force autoloading the `Deprecations` class on every single request just to configure it, I propose to allow configuring the default behavior via the `DOCTRINE_DEPRECATIONS` env var.