### PR TITLE
Add the phpstan PHPUnit plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,9 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^9",
-        "phpunit/phpunit": "^7.5|^8.5|^9.5",
         "phpstan/phpstan": "1.4.10 || 1.10.15",
+        "phpstan/phpstan-phpunit": "^1.0",
+        "phpunit/phpunit": "^7.5|^8.5|^9.5",
         "psr/log": "^1|^2|^3",
         "vimeo/psalm": "4.30.0 || 5.12.0"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,3 +3,7 @@ parameters:
     paths:
         - lib
         - tests
+
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+    - vendor/phpstan/phpstan-phpunit/rules.neon


### PR DESCRIPTION
As we are analyzing the `tests` folder, we should apply the PHPUnit-specific rules (other projects that analyze their testsuite like DoctrineMigrationsBundle already do this).
At our existing level, this does not introduce any new error.