### PR TITLE
Reach psalm level 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "phpstan/phpstan": "1.4.10 || 1.10.15",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+        "psalm/plugin-phpunit": "0.18.4",
         "psr/log": "^1 || ^2 || ^3",
         "vimeo/psalm": "4.30.0 || 5.12.0"
     },

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="3"
+    errorLevel="2"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
@@ -15,4 +15,16 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+    <issueHandlers>
+        <DeprecatedMethod>
+            <errorLevel type="suppress">
+                <!-- Remove when dropping support for PHPUnit 9.6 -->
+                <referencedMethod name="PHPUnit\Framework\TestCase::expectDeprecation"/>
+                <referencedMethod name="PHPUnit\Framework\TestCase::expectDeprecationMessage"/>
+            </errorLevel>
+        </DeprecatedMethod>
+    </issueHandlers>
 </psalm>


### PR DESCRIPTION
The error about using deprecated PHPUnit APIs are put in baseline as this code is necessary to support multiple PHPUnit versions.

Most of the level 2 errors were reported in tests and this is solved by enabling the dedicated plugin.