### PR TITLE
Add better types for the sprintf-like arguments

### DIFF
--- a/lib/Doctrine/Deprecations/Deprecation.php
+++ b/lib/Doctrine/Deprecations/Deprecation.php
@@ -69,7 +69,7 @@ class Deprecation
      * deprecation. It is additionally used to de-duplicate the trigger of the
      * same deprecation during a request.
      *
-     * @param mixed $args
+     * @param float|int|string $args
      */
     public static function trigger(string $package, string $link, string $message, ...$args): void
     {
@@ -117,7 +117,7 @@ class Deprecation
      * deprecation tracking is enabled even during deduplication, because it
      * needs to call {@link debug_backtrace()}
      *
-     * @param mixed $args
+     * @param float|int|string $args
      */
     public static function triggerIfCalledFromOutside(string $package, string $link, string $message, ...$args): void
     {


### PR DESCRIPTION
`float|int|string` is what Psalm allows for `sprintf` at level 1.
phpstan at level 9 allows `bool|float|int|string|null` for those