### PR TITLE
Fix deprecations triggered from code called by native code

### DIFF
--- a/lib/Doctrine/Deprecations/Deprecation.php
+++ b/lib/Doctrine/Deprecations/Deprecation.php
@@ -137,7 +137,7 @@ class Deprecation
         $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
 
         // first check that the caller is not from a tests folder, in which case we always let deprecations pass
-        if (strpos($backtrace[1]['file'], DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR) === false) {
+        if (isset($backtrace[1]['file'], $backtrace[0]['file']) && strpos($backtrace[1]['file'], DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR) === false) {
             $path = DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . $package . DIRECTORY_SEPARATOR;
 
             if (strpos($backtrace[0]['file'], $path) === false) {
@@ -173,7 +173,7 @@ class Deprecation
     }
 
     /**
-     * @param array<mixed> $backtrace
+     * @param list<array{function: string, line?: int, file?: string, class?: class-string, type?: string, args?: mixed[], object?: object}> $backtrace
      */
     private static function delegateTriggerToBackend(string $message, array $backtrace, string $link, string $package): void
     {
@@ -181,8 +181,8 @@ class Deprecation
 
         if (($type & self::TYPE_PSR_LOGGER) > 0) {
             $context = [
-                'file' => $backtrace[0]['file'],
-                'line' => $backtrace[0]['line'],
+                'file' => $backtrace[0]['file'] ?? null,
+                'line' => $backtrace[0]['line'] ?? null,
                 'package' => $package,
                 'link' => $link,
             ];
@@ -198,10 +198,10 @@ class Deprecation
 
         $message .= sprintf(
             ' (%s:%d called by %s:%d, %s, package %s)',
-            self::basename($backtrace[0]['file']),
-            $backtrace[0]['line'],
-            self::basename($backtrace[1]['file']),
-            $backtrace[1]['line'],
+            self::basename($backtrace[0]['file'] ?? 'native code'),
+            $backtrace[0]['line'] ?? 0,
+            self::basename($backtrace[1]['file'] ?? 'native code'),
+            $backtrace[1]['line'] ?? 0,
             $link,
             $package
         );

--- a/test_fixtures/src/ConstructorDeprecation.php
+++ b/test_fixtures/src/ConstructorDeprecation.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace DeprecationTests;
+
+use Doctrine\Deprecations\Deprecation;
+
+class ConstructorDeprecation
+{
+    public function __construct()
+    {
+        Deprecation::trigger('doctrine/bar', 'https://github.com/doctrine/deprecations/issues/44', 'This constructor is deprecated.');
+    }
+}

--- a/tests/Doctrine/Deprecations/DeprecationTest.php
+++ b/tests/Doctrine/Deprecations/DeprecationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Deprecations;
 
+use DeprecationTests\ConstructorDeprecation;
 use DeprecationTests\Foo;
 use DeprecationTests\RootDeprecation;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
@@ -11,6 +12,7 @@ use Doctrine\Foo\Baz;
 use PHPUnit\Framework\Error\Deprecated;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use ReflectionClass;
 use ReflectionProperty;
 use Throwable;
 
@@ -296,6 +298,20 @@ class DeprecationTest extends TestCase
         );
 
         Deprecation::trigger('Foo', __METHOD__, 'message');
+        $this->assertSame(1, Deprecation::getUniqueTriggeredDeprecationsCount());
+    }
+
+    public function testDeprecationTriggeredFromNativeCode(): void
+    {
+        $ref = new ReflectionClass(ConstructorDeprecation::class);
+
+        Deprecation::enableWithTriggerError();
+        $this->expectErrorHandler(
+            'This constructor is deprecated. (ConstructorDeprecation.php:%d called by native code:0, https://github.com/doctrine/deprecations/issues/44, package doctrine/bar)',
+            'https://github.com/doctrine/deprecations/issues/44'
+        );
+
+        $ref->newInstance();
         $this->assertSame(1, Deprecation::getUniqueTriggeredDeprecationsCount());
     }
 }


### PR DESCRIPTION
The debug backtrace does not provide the file key for frames that are not happening in a file, like eval'd code.

Fixes #44