### PR TITLE
Add missing wildcard characters

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,7 +10,7 @@ on:
       - lib/**
       - phpstan*
       - psalm*
-      - tests
+      - tests/**
   push:
     branches:
       - "*.x"
@@ -20,7 +20,7 @@ on:
       - lib/**
       - phpstan*
       - psalm*
-      - tests
+      - tests/**
 
 jobs:
   static-analysis:


### PR DESCRIPTION
Without them, only changes to the tests directory itself are taken into account.

Because they are missing, static analysis jobs did not run on https://github.com/doctrine/deprecations/pull/56