### PR TITLE
Adjust tests for PHP 8.3

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -27,5 +27,5 @@ jobs:
     name: "PHPUnit"
     uses: "doctrine/.github/.github/workflows/continuous-integration.yml@3.0.0"
     with:
-      php-versions: '["7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]'
+      php-versions: '["7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]'
       composer-options: '--ignore-platform-req=php+'

--- a/tests/Doctrine/Deprecations/DeprecationTest.php
+++ b/tests/Doctrine/Deprecations/DeprecationTest.php
@@ -28,11 +28,11 @@ class DeprecationTest extends TestCase
         // reset the global state of Deprecation class across tests
         $reflectionProperty = new ReflectionProperty(Deprecation::class, 'ignoredPackages');
         $reflectionProperty->setAccessible(true);
-        $reflectionProperty->setValue([]);
+        $reflectionProperty->setValue(null, []);
 
         $reflectionProperty = new ReflectionProperty(Deprecation::class, 'triggeredDeprecations');
         $reflectionProperty->setAccessible(true);
-        $reflectionProperty->setValue([]);
+        $reflectionProperty->setValue(null, []);
 
         Deprecation::disable();
 
@@ -277,12 +277,12 @@ class DeprecationTest extends TestCase
     {
         $reflectionProperty = new ReflectionProperty(Deprecation::class, 'type');
         $reflectionProperty->setAccessible(true);
-        $reflectionProperty->setValue(null);
+        $reflectionProperty->setValue(null, null);
 
         Deprecation::trigger('Foo', 'link', 'message');
         $this->assertSame(0, Deprecation::getUniqueTriggeredDeprecationsCount());
 
-        $reflectionProperty->setValue(null);
+        $reflectionProperty->setValue(null, null);
         $_SERVER['DOCTRINE_DEPRECATIONS'] = 'track';
 
         Deprecation::trigger('Foo', __METHOD__, 'message');
@@ -293,7 +293,7 @@ class DeprecationTest extends TestCase
     {
         $reflectionProperty = new ReflectionProperty(Deprecation::class, 'type');
         $reflectionProperty->setAccessible(true);
-        $reflectionProperty->setValue(null);
+        $reflectionProperty->setValue(null, null);
         $_ENV['DOCTRINE_DEPRECATIONS'] = 'trigger';
 
         $this->expectErrorHandler(


### PR DESCRIPTION
As of PHP 8.3.0, calling ReflectionProperty::setValue with a single argument is deprecated. See [1] for further reference.

[1] https://www.php.net/manual/en/reflectionproperty.setvalue.php