### PR TITLE
Rework risky test

### DIFF
--- a/tests/DeprecationTest.php
+++ b/tests/DeprecationTest.php
@@ -14,7 +14,6 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
 use ReflectionProperty;
-use Throwable;
 
 use function method_exists;
 use function set_error_handler;
@@ -139,22 +138,19 @@ class DeprecationTest extends TestCase
         $this->assertEquals(2, Deprecation::getUniqueTriggeredDeprecationsCount());
     }
 
-    public function testDeprecationResetsCounts(): void
+    public function testDisableResetsCounts(): void
     {
-        try {
-            Deprecation::trigger(
-                'doctrine/orm',
-                'https://github.com/doctrine/deprecations/1234',
-                'this is deprecated %s %d',
-                'foo',
-                1234
-            );
-        } catch (Throwable $e) {
-            Deprecation::disable();
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/deprecations/1234',
+            'this is deprecated %s %d',
+            'foo',
+            1234
+        );
+        Deprecation::disable();
 
-            $this->assertEquals(0, Deprecation::getUniqueTriggeredDeprecationsCount());
-            $this->assertEquals(['https://github.com/doctrine/deprecations/1234' => 0], Deprecation::getTriggeredDeprecations());
-        }
+        $this->assertEquals(0, Deprecation::getUniqueTriggeredDeprecationsCount());
+        $this->assertEquals(['https://github.com/doctrine/deprecations/1234' => 0], Deprecation::getTriggeredDeprecations());
     }
 
     public function expectDeprecationMock(string $message, string $identifier, string $package): LoggerInterface


### PR DESCRIPTION
PHPUnit complains that this test does not perform any assertions. That makes sense since the assertions are inside a catch block. When switching to the commit that introduced this test
(05f305b7e3a4f62112bd3248f60f4175caa3f3db), PHPUnit also mentions this issue, so it has always been broken.