### PR TITLE
Allow running tests with PHPUnit 10 and 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "doctrine/coding-standard": "^9 || ^12",
         "phpstan/phpstan": "1.4.10 || 2.0.3",
         "phpstan/phpstan-phpunit": "^1.0 || ^2",
-        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5",
         "psr/log": "^1 || ^2 || ^3"
     },
     "suggest": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,11 +10,6 @@ parameters:
             message: '/^Static property Doctrine\\Deprecations\\Deprecation::\$type \(int<0, 7>\|null\) does not accept int\.$/'
             path: src/Deprecation.php
 
-        -
-            message: '/^.*method_exists.*expectDeprecation.*$/'
-            path: tests/DeprecationTest.php
-            count: 2
-
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-phpunit/rules.neon

--- a/tests/DeprecationTest.php
+++ b/tests/DeprecationTest.php
@@ -9,13 +9,11 @@ use DeprecationTests\Foo;
 use DeprecationTests\RootDeprecation;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\Foo\Baz;
-use PHPUnit\Framework\Error\Deprecated;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
 use ReflectionProperty;
 
-use function method_exists;
 use function set_error_handler;
 
 class DeprecationTest extends TestCase
@@ -36,24 +34,6 @@ class DeprecationTest extends TestCase
         Deprecation::disable();
 
         Deprecation::enableTrackingDeprecations();
-    }
-
-    public function expectDeprecation(): void
-    {
-        if (method_exists(TestCase::class, 'expectDeprecation')) {
-            parent::expectDeprecation();
-        } else {
-            parent::expectException(Deprecated::class);
-        }
-    }
-
-    public function expectDeprecationMessage(string $message): void
-    {
-        if (method_exists(TestCase::class, 'expectDeprecationMessage')) {
-            parent::expectDeprecationMessage($message);
-        } else {
-            parent::expectExceptionMessage($message);
-        }
     }
 
     public function expectErrorHandler(string $expectedMessage, string $identifier, int $times = 1): void

--- a/tests/DeprecationTest.php
+++ b/tests/DeprecationTest.php
@@ -14,6 +14,7 @@ use Psr\Log\LoggerInterface;
 use ReflectionClass;
 use ReflectionProperty;
 
+use function restore_error_handler;
 use function set_error_handler;
 
 class DeprecationTest extends TestCase
@@ -55,30 +56,34 @@ class DeprecationTest extends TestCase
 
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/deprecations/1234');
 
-        $this->expectErrorHandler(
-            'this is deprecated foo 1234 (DeprecationTest.php:%d called by TestCase.php:%d, https://github.com/doctrine/deprecations/1234, package doctrine/orm)',
-            'https://github.com/doctrine/deprecations/1234'
-        );
+        try {
+            $this->expectErrorHandler(
+                'this is deprecated foo 1234 (DeprecationTest.php:%d called by TestCase.php:%d, https://github.com/doctrine/deprecations/1234, package doctrine/orm)',
+                'https://github.com/doctrine/deprecations/1234'
+            );
 
-        Deprecation::trigger(
-            'doctrine/orm',
-            'https://github.com/doctrine/deprecations/1234',
-            'this is deprecated %s %d',
-            'foo',
-            1234
-        );
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/deprecations/1234',
+                'this is deprecated %s %d',
+                'foo',
+                1234
+            );
 
-        $this->assertEquals(1, Deprecation::getUniqueTriggeredDeprecationsCount());
+            $this->assertEquals(1, Deprecation::getUniqueTriggeredDeprecationsCount());
 
-        Deprecation::trigger(
-            'doctrine/orm',
-            'https://github.com/doctrine/deprecations/1234',
-            'this is deprecated %s %d',
-            'foo',
-            1234
-        );
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/deprecations/1234',
+                'this is deprecated %s %d',
+                'foo',
+                1234
+            );
 
-        $this->assertEquals(2, Deprecation::getUniqueTriggeredDeprecationsCount());
+            $this->assertEquals(2, Deprecation::getUniqueTriggeredDeprecationsCount());
+        } finally {
+            restore_error_handler();
+        }
     }
 
     public function testDeprecationWithoutDeduplication(): void
@@ -86,36 +91,41 @@ class DeprecationTest extends TestCase
         Deprecation::enableWithTriggerError();
         Deprecation::withoutDeduplication();
 
-        $this->expectErrorHandler(
-            'this is deprecated foo 2222 (DeprecationTest.php:%d called by TestCase.php:%d, https://github.com/doctrine/deprecations/2222, package doctrine/orm)',
-            'https://github.com/doctrine/deprecations/2222'
-        );
+        try {
+            $this->expectErrorHandler(
+                'this is deprecated foo 2222 (DeprecationTest.php:%d called by TestCase.php:%d, https://github.com/doctrine/deprecations/2222, package doctrine/orm)',
+                'https://github.com/doctrine/deprecations/2222'
+            );
 
-        Deprecation::trigger(
-            'doctrine/orm',
-            'https://github.com/doctrine/deprecations/2222',
-            'this is deprecated %s %d',
-            'foo',
-            2222
-        );
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/deprecations/2222',
+                'this is deprecated %s %d',
+                'foo',
+                2222
+            );
 
-        $this->assertEquals(1, Deprecation::getUniqueTriggeredDeprecationsCount());
+            $this->assertEquals(1, Deprecation::getUniqueTriggeredDeprecationsCount());
+            restore_error_handler();
 
-        $this->expectErrorHandler(
-            'this is deprecated foo 2222 (DeprecationTest.php:%d called by TestCase.php:%d, https://github.com/doctrine/deprecations/2222, package doctrine/orm)',
-            'https://github.com/doctrine/deprecations/2222',
-            2
-        );
+            $this->expectErrorHandler(
+                'this is deprecated foo 2222 (DeprecationTest.php:%d called by TestCase.php:%d, https://github.com/doctrine/deprecations/2222, package doctrine/orm)',
+                'https://github.com/doctrine/deprecations/2222',
+                2
+            );
 
-        Deprecation::trigger(
-            'doctrine/orm',
-            'https://github.com/doctrine/deprecations/2222',
-            'this is deprecated %s %d',
-            'foo',
-            2222
-        );
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/deprecations/2222',
+                'this is deprecated %s %d',
+                'foo',
+                2222
+            );
 
-        $this->assertEquals(2, Deprecation::getUniqueTriggeredDeprecationsCount());
+            $this->assertEquals(2, Deprecation::getUniqueTriggeredDeprecationsCount());
+        } finally {
+            restore_error_handler();
+        }
     }
 
     public function testDisableResetsCounts(): void
@@ -202,16 +212,20 @@ class DeprecationTest extends TestCase
 
     public function testDeprecationIfCalledFromOutside(): void
     {
-        Deprecation::enableWithTriggerError();
+            Deprecation::enableWithTriggerError();
 
-        $this->expectErrorHandler(
-            'Bar::oldFunc() is deprecated, use Bar::newFunc() instead. (Bar.php:%d called by Foo.php:14, https://github.com/doctrine/foo, package doctrine/foo)',
-            'https://github.com/doctrine/foo'
-        );
+        try {
+            $this->expectErrorHandler(
+                'Bar::oldFunc() is deprecated, use Bar::newFunc() instead. (Bar.php:%d called by Foo.php:14, https://github.com/doctrine/foo, package doctrine/foo)',
+                'https://github.com/doctrine/foo'
+            );
 
-        Foo::triggerDependencyWithDeprecation();
+            Foo::triggerDependencyWithDeprecation();
 
-        $this->assertEquals(1, Deprecation::getUniqueTriggeredDeprecationsCount());
+            $this->assertEquals(1, Deprecation::getUniqueTriggeredDeprecationsCount());
+        } finally {
+            restore_error_handler();
+        }
     }
 
     public function testDeprecationIfCalledFromOutsideNotTriggeringFromInside(): void
@@ -239,14 +253,18 @@ class DeprecationTest extends TestCase
 
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/deprecations/4444');
 
-        $this->expectErrorHandler(
-            'this is deprecated foo 1234 (RootDeprecation.php:%d called by DeprecationTest.php:%d, https://github.com/doctrine/deprecations/4444, package doctrine/orm)',
-            'https://github.com/doctrine/deprecations/4444'
-        );
+        try {
+            $this->expectErrorHandler(
+                'this is deprecated foo 1234 (RootDeprecation.php:%d called by DeprecationTest.php:%d, https://github.com/doctrine/deprecations/4444, package doctrine/orm)',
+                'https://github.com/doctrine/deprecations/4444'
+            );
 
-        RootDeprecation::run();
+            RootDeprecation::run();
 
-        $this->assertEquals(1, Deprecation::getUniqueTriggeredDeprecationsCount());
+            $this->assertEquals(1, Deprecation::getUniqueTriggeredDeprecationsCount());
+        } finally {
+            restore_error_handler();
+        }
     }
 
     public function testDeprecationTrackByEnv(): void
@@ -272,13 +290,17 @@ class DeprecationTest extends TestCase
         $reflectionProperty->setValue(null, null);
         $_ENV['DOCTRINE_DEPRECATIONS'] = 'trigger';
 
-        $this->expectErrorHandler(
-            'message (DeprecationTest.php:%d called by TestCase.php:%d, ' . __METHOD__ . ', package Foo)',
-            __METHOD__
-        );
+        try {
+            $this->expectErrorHandler(
+                'message (DeprecationTest.php:%d called by TestCase.php:%d, ' . __METHOD__ . ', package Foo)',
+                __METHOD__
+            );
 
-        Deprecation::trigger('Foo', __METHOD__, 'message');
-        $this->assertSame(1, Deprecation::getUniqueTriggeredDeprecationsCount());
+            Deprecation::trigger('Foo', __METHOD__, 'message');
+            $this->assertSame(1, Deprecation::getUniqueTriggeredDeprecationsCount());
+        } finally {
+            restore_error_handler();
+        }
     }
 
     public function testDeprecationTriggeredFromNativeCode(): void
@@ -286,12 +308,16 @@ class DeprecationTest extends TestCase
         $ref = new ReflectionClass(ConstructorDeprecation::class);
 
         Deprecation::enableWithTriggerError();
-        $this->expectErrorHandler(
-            'This constructor is deprecated. (ConstructorDeprecation.php:%d called by native code:0, https://github.com/doctrine/deprecations/issues/44, package doctrine/bar)',
-            'https://github.com/doctrine/deprecations/issues/44'
-        );
+        try {
+            $this->expectErrorHandler(
+                'This constructor is deprecated. (ConstructorDeprecation.php:%d called by native code:0, https://github.com/doctrine/deprecations/issues/44, package doctrine/bar)',
+                'https://github.com/doctrine/deprecations/issues/44'
+            );
 
-        $ref->newInstance();
-        $this->assertSame(1, Deprecation::getUniqueTriggeredDeprecationsCount());
+            $ref->newInstance();
+            $this->assertSame(1, Deprecation::getUniqueTriggeredDeprecationsCount());
+        } finally {
+            restore_error_handler();
+        }
     }
 }

--- a/tests/VerifyDeprecationsTest.php
+++ b/tests/VerifyDeprecationsTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Deprecations;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use PHPUnit\Framework\TestCase;
 
+use function restore_error_handler;
 use function set_error_handler;
 
 class VerifyDeprecationsTest extends TestCase
@@ -18,6 +19,11 @@ class VerifyDeprecationsTest extends TestCase
         set_error_handler(static function (): bool {
             return false;
         });
+    }
+
+    public function tearDown(): void
+    {
+        restore_error_handler();
     }
 
     public function testExpectDeprecationWithIdentifier(): void


### PR DESCRIPTION
PHPUnit 11 emits complaints about the error handlers not being removed, which is risky, so I had to add a few calls to `restore_error_handler()`.

This leaves us with PHPUnit deprecations about using `@before` and `@after` rather than the corresponding attributes. I do not think those can be addressed without a breaking change (adding the attributes is not enough, you have to remove the annotations).


After this MR is merged, `composer outdated` is almost empty:

```
Color legend:
- patch or minor release available - update recommended
- major release available - update possible

Direct dependencies required in composer.json:
Everything up to date

Transitive dependencies not required in composer.json:
phpstan/phpdoc-parser 1.33.0 2.0.0 PHPDoc parser with support for nullable, intersection and generic types
```