### PR TITLE
Drop support for old PHPUnit versions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,4 +28,3 @@ jobs:
     uses: "doctrine/.github/.github/workflows/continuous-integration.yml@7.1.0"
     with:
       php-versions: '["8.1", "8.2", "8.3"]'
-      composer-options: '--ignore-platform-req=php+'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -27,5 +27,5 @@ jobs:
     name: "PHPUnit"
     uses: "doctrine/.github/.github/workflows/continuous-integration.yml@7.1.0"
     with:
-      php-versions: '["7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]'
+      php-versions: '["8.1", "8.2", "8.3"]'
       composer-options: '--ignore-platform-req=php+'

--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,17 @@
     "type": "library",
     "homepage": "https://www.doctrine-project.org/",
     "require": {
-        "php": "^7.1 || ^8.0"
+        "php": "^8.1"
     },
     "require-dev": {
         "doctrine/coding-standard": "^9 || ^12",
         "phpstan/phpstan": "1.4.10 || 2.0.3",
         "phpstan/phpstan-phpunit": "^1.0 || ^2",
-        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5",
+        "phpunit/phpunit": "^10.5 || ^11.5",
         "psr/log": "^1 || ^2 || ^3"
+    },
+    "conflict": {
+        "phpunit/phpunit": "<=10.5 || >=12"
     },
     "suggest": {
         "psr/log": "Allows logging deprecations via PSR-3 logger implementation"

--- a/src/PHPUnit/VerifyDeprecations.php
+++ b/src/PHPUnit/VerifyDeprecations.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\Deprecations\PHPUnit;
 
 use Doctrine\Deprecations\Deprecation;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
 
 use function sprintf;
 
@@ -26,13 +28,13 @@ trait VerifyDeprecations
         $this->doctrineNoDeprecationsExpectations[$identifier] = Deprecation::getTriggeredDeprecations()[$identifier] ?? 0;
     }
 
-    /** @before */
+    #[Before]
     public function enableDeprecationTracking(): void
     {
         Deprecation::enableTrackingDeprecations();
     }
 
-    /** @after */
+    #[After]
     public function verifyDeprecationsAreTriggered(): void
     {
         foreach ($this->doctrineDeprecationsExpectations as $identifier => $expectation) {


### PR DESCRIPTION
That implies bumping the version of PHP, and should make PHPUnit deprecations about `@before` and `@after` go away.