### PR TITLE
Make deduplication configurable from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ Alternatively, call:
 \Doctrine\Deprecations\Deprecation::enableTrackingDeprecations();
 ```
 
+To disable deduplication (useful for testing), set the `DOCTRINE_DEPRECATIONS_DEDUPLICATION`
+environment variable to `false`. Alternatively, call:
+
+```php
+\Doctrine\Deprecations\Deprecation::withoutDeduplication();
+```
+
 Tracking is enabled with all three modes and provides access to all triggered
 deprecations and their individual count:
 
@@ -182,8 +189,14 @@ deprecations triggered during the test suite execution.
 Note that you can still trigger Deprecations in your code, provided you use the
 `#[IgnoreDeprecations]` to ignore them for tests that call it.
 
-At the moment, it is not possible to disable deduplication with an environment
-variable, but you can use a bootstrap file to achieve that:
+You can disable deduplication by setting the `DOCTRINE_DEPRECATIONS_DEDUPLICATION`
+environment variable to `false`:
+
+```bash
+DOCTRINE_DEPRECATIONS_DEDUPLICATION=false vendor/bin/phpunit
+```
+
+Alternatively, you can use a bootstrap file to achieve the same effect:
 
 ```php
 // tests/bootstrap.php

--- a/src/Deprecation.php
+++ b/src/Deprecation.php
@@ -63,8 +63,8 @@ class Deprecation
     /** @var array<string,bool> */
     private static $ignoredLinks = [];
 
-    /** @var bool */
-    private static $deduplication = true;
+    /** @var bool|null */
+    private static $deduplication;
 
     /**
      * Trigger a deprecation for the given package and identfier.
@@ -93,7 +93,7 @@ class Deprecation
             self::$triggeredDeprecations[$link] = 1;
         }
 
-        if (self::$deduplication === true && self::$triggeredDeprecations[$link] > 1) {
+        if ((self::$deduplication ?? self::getDeduplicationFromEnv()) === true && self::$triggeredDeprecations[$link] > 1) {
             return;
         }
 
@@ -160,7 +160,7 @@ class Deprecation
             self::$triggeredDeprecations[$link] = 1;
         }
 
-        if (self::$deduplication === true && self::$triggeredDeprecations[$link] > 1) {
+        if ((self::$deduplication ?? self::getDeduplicationFromEnv()) === true && self::$triggeredDeprecations[$link] > 1) {
             return;
         }
 
@@ -250,7 +250,7 @@ class Deprecation
     {
         self::$type          = self::TYPE_NONE;
         self::$logger        = null;
-        self::$deduplication = true;
+        self::$deduplication = null;
         self::$ignoredLinks  = [];
 
         foreach (self::$triggeredDeprecations as $link => $count) {
@@ -305,5 +305,16 @@ class Deprecation
         }
 
         return self::$type;
+    }
+
+    private static function getDeduplicationFromEnv(): bool
+    {
+        $envValue = $_SERVER['DOCTRINE_DEPRECATIONS_DEDUPLICATION'] ?? $_ENV['DOCTRINE_DEPRECATIONS_DEDUPLICATION'] ?? null;
+
+        if ($envValue === 'false' || $envValue === '0') {
+            return self::$deduplication = false;
+        }
+
+        return self::$deduplication = true;
     }
 }

--- a/tests/DeprecationTest.php
+++ b/tests/DeprecationTest.php
@@ -320,4 +320,87 @@ class DeprecationTest extends TestCase
             restore_error_handler();
         }
     }
+
+    public function testDeprecationWithoutDeduplicationByEnv(): void
+    {
+        $_ENV['DOCTRINE_DEPRECATIONS_DEDUPLICATION'] = 'false';
+
+        Deprecation::enableWithTriggerError();
+
+        $errorCount = 0;
+        set_error_handler(static function () use (&$errorCount): bool {
+            $errorCount++;
+
+            return true;
+        });
+
+        try {
+            // Trigger the same deprecation multiple times
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/deprecations/issues/123',
+                'this is deprecated from env test'
+            );
+
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/deprecations/issues/123',
+                'this is deprecated from env test'
+            );
+
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/deprecations/issues/123',
+                'this is deprecated from env test'
+            );
+
+            $this->assertEquals(3, $errorCount, 'Expected 3 deprecation warnings to be triggered');
+            $this->assertEquals(3, Deprecation::getUniqueTriggeredDeprecationsCount());
+        } finally {
+            restore_error_handler();
+            unset($_ENV['DOCTRINE_DEPRECATIONS_DEDUPLICATION']);
+        }
+    }
+
+    public function testDeprecationWithDeduplicationEnabledByDefault(): void
+    {
+        // Ensure no environment variable is set
+        unset($_ENV['DOCTRINE_DEPRECATIONS_DEDUPLICATION']);
+
+        Deprecation::enableWithTriggerError();
+
+        $errorCount = 0;
+        set_error_handler(static function () use (&$errorCount): bool {
+            $errorCount++;
+
+            return true;
+        });
+
+        try {
+            // Trigger the same deprecation multiple times
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/deprecations/issues/123',
+                'this is deprecated default test'
+            );
+
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/deprecations/issues/123',
+                'this is deprecated default test'
+            );
+
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/deprecations/issues/123',
+                'this is deprecated default test'
+            );
+
+            // With deduplication enabled (default), only first should trigger
+            $this->assertEquals(1, $errorCount);
+            $this->assertEquals(3, Deprecation::getUniqueTriggeredDeprecationsCount());
+        } finally {
+            restore_error_handler();
+        }
+    }
 }


### PR DESCRIPTION
When in the context of PHPUnit tests, using a bootstrap file is not very convenient.

Prompted by https://github.com/doctrine/collections/pull/472

Disclaimer: I used opencode + Claude Sonnet for this.